### PR TITLE
partition() returns corner position and other data

### DIFF
--- a/R/partition.R
+++ b/R/partition.R
@@ -117,7 +117,7 @@ contains_corner <- function(.data, corners) {
 #'
 #' # Given a set of cells in columns 1 to 10, partition them at the 3rd, 5th and
 #' # 7th column.  This example is exactly the same as the previous one, to show
-#' that the function works the same way on columns as rows.
+#' # that the function works the same way on columns as rows.
 #' partition_dim(1:10, c(3, 5, 7))
 #'
 #' # Given a set of cells in rows 1 to 10, partition them at the 3rd, 5th and

--- a/R/partition.R
+++ b/R/partition.R
@@ -2,22 +2,17 @@
 #'
 #' @description
 #' Given the positions of corner cells that mark individual tables in a single
-#' spreadsheet, `partion()` works out which cells belong to which tables, and
-#' gives them an ID.  This can be used with `dplyr::group_by()` or
-#' `tidyr::nest()` to operate on each single table within a spreadsheet of
-#' several tables.
-#'
-#' Corners must all be in the top-left, or bottom-left, or top-right, or
-#' bottom-right of each table.
+#' spreadsheet, `partion()` works out which table cells belong to which corner
+#' cells.  The individual tables can then be worked on independently.
 #'
 #' `partition()` partitions along both dimensions (rows and columns) at once.
 #' `partition_dim()` partitions along one dimension at a time.
 #'
 #' @param cells Data frame or tbl, the cells to be partitioned, from
 #'   [as_cells()] or [tidyxl::xlsx_cells()].
-#' @param corners a subset of `cells`, being the corners of individual tables.
-#' @param partition_name Character vector length 1, what to call the new column
-#'   that will be created to identify the partitions.  Default: `"partition"`.
+#' @param corners usually a subset of `cells`, being the corners of individual
+#'   tables.  Can also be cells that aren't among `cells`, in which case see the
+#'   `strict` argument.
 #' @param align Character, the position of the corner cells relative to their
 #'   tables, one of `"top-left"` (default), `"top-right"`, `"bottom-left"`,
 #'   `"bottom-right"`.
@@ -73,26 +68,25 @@
 #' partition(multiples, bl_corners, align = "bottom_left")
 #' partition(multiples, bl_corners, align = "bottom_left", strict = FALSE)
 partition <- function(cells, corners, align = "top_left",
-                     partition_name = "partition", nest = TRUE, strict = TRUE) {
+                     nest = TRUE, strict = TRUE) {
   check_distinct(cells)
   if (!(align %in% c("top_left", "top_right",
                        "bottom_left", "bottom_right"))) {
     stop("`align` must be one of:
          \"top_left\", \"top_right\", \"bottom_left\", \"bottom_right\"")
   }
-  partition_name <- rlang::ensym(partition_name)
   row_bound <- (if(align %in% c("top_left", "top_right")) "upper" else "lower")
   col_bound <- (if(align %in% c("top_left", "bottom_left")) "upper" else "lower")
-  row_groups <- partition_dim(cells$row, unique(corners$row), row_bound)
-  col_groups <- partition_dim(cells$col, unique(corners$col), col_bound)
+  row_groups <- partition_dim(cells$row, sort(unique(corners$row)), row_bound)
+  col_groups <- partition_dim(cells$col, sort(unique(corners$col)), col_bound)
+  join_names <- c("row", "col")
+  names(join_names) <- c("corner_row", "corner_col")
   out <-
     cells %>%
-    dplyr::mutate(!! partition_name := paste(row_groups,
-                                             col_groups,
-                                             sep = ",")) %>%
-    dplyr::filter(row_groups >= 1, col_groups >= 1) %>%
-    dplyr::mutate(!! partition_name := as.integer(factor(!! partition_name))) %>%
-    tidyr::nest(-(!! partition_name), .key = "cells")
+    dplyr::mutate(corner_row = row_groups,
+                  corner_col = col_groups) %>%
+    tidyr::nest(-corner_row, -corner_col, .key = "cells") %>%
+    dplyr::inner_join(corners, by = join_names)
   if (strict) {
     out <- dplyr::filter(out, purrr::map_lgl(cells, contains_corner, corners))
   }
@@ -118,40 +112,32 @@ contains_corner <- function(.data, corners) {
 #' @export
 #' @examples
 #' # Given a set of cells in rows 1 to 10, partition them at the 3rd, 5th and 7th
-#' # rows. Row 3 is the top row of group 1.
+#' # rows.
 #' partition_dim(1:10, c(3, 5, 7))
 #'
 #' # Given a set of cells in columns 1 to 10, partition them at the 3rd, 5th and
-#' # 7th column. Column 3 is the left-most column of group 1.
-#' # This example is exactly the same as the previous one, to show that the
-#' # function works the same way on columns as rows.
+#' # 7th column.  This example is exactly the same as the previous one, to show
+#' that the function works the same way on columns as rows.
 #' partition_dim(1:10, c(3, 5, 7))
 #'
 #' # Given a set of cells in rows 1 to 10, partition them at the 3rd, 5th and
-#' # 7th rows. Row 7 is the bottom row of group 1
+#' # 7th rows, aligned to the bottom of the group.
 #' partition_dim(1:10, c(3, 5, 7), bound = "lower")
 #'
-#' # When the first row of cells is on the first cutpoint, there is no group 0.
-#' partition_dim(1:10, c(1, 10))
-#' partition_dim(1:10, c(1, 10), bound = "lower")
-#'
 #' # Non-integer row/column numbers and cutpoints can be used, even though they
-#' # make no sense in the context of partioning grids of cells.
+#' # make no sense in the context of partioning grids of cells.  They are
+#' # rounded towards zero first.
 #' partition_dim(1:10 - .5, c(3, 5, 7))
 #' partition_dim(1:10, c(3, 5, 7) + 1.5)
 partition_dim <- function(positions, cutpoints, bound = "upper") {
   if (!(bound %in% c("upper", "lower"))) {
     stop("`bound` must be one of \"upper\", \"lower\"")
   }
-  cutpoints <- c(-Inf, sort(cutpoints, decreasing = bound == "lower"), Inf)
-  labels <-
-    if(length(cutpoints) == 0) {
-    } else {
-      sort(seq_along(cutpoints[-1]) - 1, decreasing = bound == "lower")
-    }
-  cut(positions, cutpoints, right = bound == "lower", labels = labels) %>%
-    as.character() %>%
-    as.integer()
+  cutpoints <- sort(c(-Inf, cutpoints, Inf), decreasing = bound == "lower")
+  labels <- trunc(sort(cutpoints[-length(cutpoints)]))
+  labels[is.infinite(labels)] <- NA
+  out <- cut(positions, cutpoints, right = bound == "lower", labels = FALSE)
+  labels[out]
 }
 
 # Other names that were considered for 'partition()'

--- a/R/utils.R
+++ b/R/utils.R
@@ -35,6 +35,8 @@ globalVariables(c(".",
                   ":=",
                   ".partition",
                   "ns_env",
+                  "corner_row",
+                  "corner_col",
                   ".boundary"))
 
 # Concatenate lists into vectors, handling factors and NULLs, and coercing data

--- a/man/partition.Rd
+++ b/man/partition.Rd
@@ -99,7 +99,7 @@ partition_dim(1:10, c(3, 5, 7))
 
 # Given a set of cells in columns 1 to 10, partition them at the 3rd, 5th and
 # 7th column.  This example is exactly the same as the previous one, to show
-that the function works the same way on columns as rows.
+# that the function works the same way on columns as rows.
 partition_dim(1:10, c(3, 5, 7))
 
 # Given a set of cells in rows 1 to 10, partition them at the 3rd, 5th and

--- a/man/partition.Rd
+++ b/man/partition.Rd
@@ -5,8 +5,7 @@
 \alias{partition_dim}
 \title{Divide a grid of cells into partitions containing individual tables}
 \usage{
-partition(cells, corners, align = "top_left", partition_name = "partition",
-  nest = TRUE, strict = TRUE)
+partition(cells, corners, align = "top_left", nest = TRUE, strict = TRUE)
 
 partition_dim(positions, cutpoints, bound = "upper")
 }
@@ -14,14 +13,13 @@ partition_dim(positions, cutpoints, bound = "upper")
 \item{cells}{Data frame or tbl, the cells to be partitioned, from
 \code{\link[=as_cells]{as_cells()}} or \code{\link[tidyxl:xlsx_cells]{tidyxl::xlsx_cells()}}.}
 
-\item{corners}{a subset of \code{cells}, being the corners of individual tables.}
+\item{corners}{usually a subset of \code{cells}, being the corners of individual
+tables.  Can also be cells that aren't among \code{cells}, in which case see the
+\code{strict} argument.}
 
 \item{align}{Character, the position of the corner cells relative to their
 tables, one of \code{"top-left"} (default), \code{"top-right"}, \code{"bottom-left"},
 \code{"bottom-right"}.}
-
-\item{partition_name}{Character vector length 1, what to call the new column
-that will be created to identify the partitions.  Default: \code{"partition"}.}
 
 \item{nest}{Logical, whether to nest the partitions in a list-column of data
 frames.}
@@ -59,13 +57,8 @@ grid of cells into chunks along both dimensions
 }
 \description{
 Given the positions of corner cells that mark individual tables in a single
-spreadsheet, \code{partion()} works out which cells belong to which tables, and
-gives them an ID.  This can be used with \code{dplyr::group_by()} or
-\code{tidyr::nest()} to operate on each single table within a spreadsheet of
-several tables.
-
-Corners must all be in the top-left, or bottom-left, or top-right, or
-bottom-right of each table.
+spreadsheet, \code{partion()} works out which table cells belong to which corner
+cells.  The individual tables can then be worked on independently.
 
 \code{partition()} partitions along both dimensions (rows and columns) at once.
 \code{partition_dim()} partitions along one dimension at a time.
@@ -101,25 +94,21 @@ bl_corners <- bl_corners[-1, ]
 partition(multiples, bl_corners, align = "bottom_left")
 partition(multiples, bl_corners, align = "bottom_left", strict = FALSE)
 # Given a set of cells in rows 1 to 10, partition them at the 3rd, 5th and 7th
-# rows. Row 3 is the top row of group 1.
+# rows.
 partition_dim(1:10, c(3, 5, 7))
 
 # Given a set of cells in columns 1 to 10, partition them at the 3rd, 5th and
-# 7th column. Column 3 is the left-most column of group 1.
-# This example is exactly the same as the previous one, to show that the
-# function works the same way on columns as rows.
+# 7th column.  This example is exactly the same as the previous one, to show
+that the function works the same way on columns as rows.
 partition_dim(1:10, c(3, 5, 7))
 
 # Given a set of cells in rows 1 to 10, partition them at the 3rd, 5th and
-# 7th rows. Row 7 is the bottom row of group 1
+# 7th rows, aligned to the bottom of the group.
 partition_dim(1:10, c(3, 5, 7), bound = "lower")
 
-# When the first row of cells is on the first cutpoint, there is no group 0.
-partition_dim(1:10, c(1, 10))
-partition_dim(1:10, c(1, 10), bound = "lower")
-
 # Non-integer row/column numbers and cutpoints can be used, even though they
-# make no sense in the context of partioning grids of cells.
+# make no sense in the context of partioning grids of cells.  They are
+# rounded towards zero first.
 partition_dim(1:10 - .5, c(3, 5, 7))
 partition_dim(1:10, c(3, 5, 7) + 1.5)
 }

--- a/tests/testthat/test-behead.R
+++ b/tests/testthat/test-behead.R
@@ -20,18 +20,26 @@ test_that("behead() works", {
 })
 
 test_that("the `drop_na` argument of behead() works", {
-  # Strip the headers and make them into data
   tidy <-
     cells %>%
-    behead("N", "Sex", drop_na = FALSE) %>%
+    behead("NNW", "Sex", drop_na = TRUE) %>%
     behead("N", "Sense of purpose") %>%
     behead("WNW", "Highest qualification") %>%
     behead("W", "Age group (Life-stages)") %>%
-    # dplyr::select(-row, -col, -data_type, -chr)
-    dplyr::select(-row, -col, -data_type)
+    dplyr::select(-row, -col, -data_type, -chr)
   # Check against the provided 'tidy' version of the data.
   expect_equal(nrow(tidy), 80)
-  expect_equal(tidy$Sex, rep(c("Female", NA, "Male", NA), each = 20))
+  expect_equal(tidy$Sex, rep(rep(c("Female", "Male"), each = 8), 5))
+  tidy <-
+    cells %>%
+    behead("NNW", "Sex", drop_na = FALSE) %>%
+    behead("N", "Sense of purpose") %>%
+    behead("WNW", "Highest qualification") %>%
+    behead("W", "Age group (Life-stages)") %>%
+    dplyr::select(-row, -col, -data_type, -chr)
+  # Check against the provided 'tidy' version of the data.
+  expect_equal(nrow(tidy), 80)
+  expect_equal(tidy$Sex, rep(rep(c("Female", NA, "Male", NA), each = 4), 5))
 })
 
 test_that("``\"ABOVE\"`` etc. don't work", {

--- a/tests/testthat/test-partition.R
+++ b/tests/testthat/test-partition.R
@@ -3,24 +3,24 @@ context("partition")
 test_that("partition_dim() works", {
   # Positions before the first partition are put into group 0
   expect_equal(partition_dim(1:10, c(3, 5, 7)),
-               c(0, 0, 1, 1, 2, 2, 3, 3, 3, 3))
+               c(NA, NA, 3, 3, 5, 5, 7, 7, 7, 7))
   # Groups are numbered in reverse for lower bounds
   expect_equal(partition_dim(1:10, c(3, 5, 7), bound = "lower"),
-               c(3, 3, 3, 2, 2, 1, 1, 0, 0, 0))
+               c(3, 3, 3, 5, 5, 7, 7, NA, NA, NA))
   # When the first row of cells is on the first cutpoint, there is no group 0.
   expect_equal(partition_dim(1:10, c(1, 10)),
-               c(rep(1, 9), 2))
+               c(rep(1, 9), 10))
   expect_equal(partition_dim(1:10, c(1, 10), bound = "lower"),
-               c(2, rep(1, 9)))
+               c(1, rep(10, 9)))
   # Non-integer row/column numbers and cutpoints can be used, even though they
   # make no sense in the context of partioning grids of cells.
   expect_equal(partition_dim(1:10 - .5, c(3, 5, 7)),
-               c(0, 0, 0, 1, 1, 2, 2, 3, 3, 3))
+               c(NA, NA, NA, 3, 3, 5, 5, 7, 7, 7))
   expect_equal(partition_dim(1:10, c(3, 5, 7) + 1.5),
-               c(0, 0, 0, 0, 1, 1, 2, 2, 3, 3))
+               c(NA, NA, NA, NA, 4, 4, 6, 6, 8, 8))
   # When there is no cutpoint, everything is put into group 0
   expect_equal(partition_dim(1:10, integer()),
-               rep(0, 10))
+               rep(NA_integer_, 10))
 })
 
 test_that("partition_dim() catches argument errors", {
@@ -33,15 +33,16 @@ test_that("partition() works", {
   tl_corners <-
     dplyr::filter(multiples,
                   !is.na(character),
-                  !(character %in% c("Sex", "Value", "Female", "Male")))
-  expect_equal(partition(multiples, tl_corners, nest = FALSE)$partition,
-               rep(c(1, 3, 5, 2, 4), each = 8))
+                  !(character %in% c("Sex", "Value", "Female", "Male"))) %>%
+    dplyr::select(row, col, qualification = character)
+  expect_equal(partition(multiples, tl_corners, nest = FALSE)$corner_row,
+               rep(c(1, 6, 11, 1, 6), each = 8))
   bl_corners <- dplyr::filter(multiples, character == "Male")
   expect_equal(partition(multiples,
                          bl_corners,
                          align = "bottom_left",
-                         nest = FALSE)$partition,
-               rep(c(4, 2, 1, 5, 3), each = 8))
+                         nest = FALSE)$corner_row,
+               rep(c(4, 9, 14, 4, 9), each = 8))
   tr_corners <-
     multiples %>%
     dplyr::filter(character == "Value") %>%
@@ -49,8 +50,8 @@ test_that("partition() works", {
   expect_equal(partition(multiples,
                          tr_corners,
                          align = "top_right",
-                         nest = FALSE)$partition,
-               rep(c(2, 4, 5, 1, 3), each = 8))
+                         nest = FALSE)$corner_row,
+               rep(c(1, 6, 11, 1, 6), each = 8))
   br_corners <-
     multiples %>%
     dplyr::filter(character == "Male") %>%
@@ -58,8 +59,8 @@ test_that("partition() works", {
   expect_equal(partition(multiples,
                          br_corners,
                          align = "bottom_right",
-                         nest = FALSE)$partition,
-               rep(c(5, 3, 1, 4, 2), each = 8))
+                         nest = FALSE)$corner_row,
+               rep(c(4, 9, 14, 4, 9), each = 8))
 })
 
 test_that("partition() arguments are checked", {


### PR DESCRIPTION
This is a feature change of partition.

Rather than give partitions meaningless
IDs, it returns the corner positions of the corner cells that mark each
partition.  This means that it's easy to join the corner cells.

You probably don't need to join the corner cells any more, because any columns
other than `row` and `col` will now be returned anyway, so that corners with
values can be used as headers.