### PR TITLE
Compatibility with tibble 2.1.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     purrr,
     tidyr,
     pillar,
-    tibble,
+    tibble (>= 2.1.1),
     cellranger,
     xml2
 URL: https://github.com/nacnudus/unpivotr

--- a/R/as_cells.R
+++ b/R/as_cells.R
@@ -95,29 +95,29 @@ as_cells.data.frame <- function(x, row_names = FALSE, col_names = FALSE) {
   ncols <- ncol(x)
   types <- purrr::map_chr(x, pillar::type_sum)
   # Spread cells into different columns by data type
-  out <- tibble::data_frame(row = rep.int(seq_len(nrow(x)), ncols),
-                            col = rep(seq_len(ncol(x)), each = nrows),
-                            value = values,
-                            type = rep(types, each = nrows),
-                            data_type = type)
+  out <- tibble::tibble(row = rep.int(seq_len(nrow(x)), ncols),
+                        col = rep(seq_len(ncol(x)), each = nrows),
+                        value = values,
+                        type = rep(types, each = nrows),
+                        data_type = type)
   out <- tidyr::spread(out, type, value)
   if (row_names) {
     rnames <- row.names(x)
     out$col <- out$col + 1L
     out <- dplyr::bind_rows(out,
-                            tibble::data_frame(col = 1L,
-                                               row = seq_along(rnames),
-                                               chr = rlang::as_list(rnames),
-                                               data_type = "chr"))
+                            tibble::tibble(col = 1L,
+                                           row = seq_along(rnames),
+                                           chr = rlang::as_list(rnames),
+                                           data_type = "chr"))
   }
   if (col_names) {
     cnames <- colnames(x)
     out$row <- out$row + 1L
     out <- dplyr::bind_rows(out,
-                            tibble::data_frame(row = 1L,
-                                               col = seq_along(cnames) + row_names,
-                                               chr = rlang::as_list(cnames),
-                                               data_type = "chr"))
+                            tibble::tibble(row = 1L,
+                                           col = seq_along(cnames) + row_names,
+                                           chr = rlang::as_list(cnames),
+                                           data_type = "chr"))
   }
   # Convert non-list-columns to vectors
   out <- dplyr::mutate_at(out,

--- a/R/as_cells.R
+++ b/R/as_cells.R
@@ -198,7 +198,7 @@ as_cells.xml_node <- function(x, row_names = FALSE, col_names = FALSE) {
   out <- purrr::transpose(out)
   out <- purrr::map(out, purrr::flatten_chr)
   out <- tibble::set_tidy_names(out, quiet = TRUE)
-  out <- tibble::as_data_frame(out)
+  out <- tibble::as_tibble(out, .name_repair = "minimal")
   out <- as_cells(out, row_names = FALSE, col_names = FALSE)
   out[, c("double", "integer", "logical")] <- NULL
   colnames(out) <- c("row", "col", "data_type", "html")

--- a/R/pack.R
+++ b/R/pack.R
@@ -109,7 +109,7 @@ pack <- function(cells, types = data_type, name = "value", drop_types = TRUE,
   type_values <- unique(dplyr::pull(cells, !! types))
   patterns <-
     map(type_values,
-        ~ rlang::expr(!! types == !!.x ~ as.list(!!!rlang::ensym(.x))))
+        ~ rlang::expr(!! types == !!.x ~ as.list(!! rlang::ensym(.x))))
   out <- dplyr::mutate(cells, !! name := dplyr::case_when(!!! patterns))
   # Name the elements of the packed value column by their types
   names(out[[rlang::expr_text(name)]]) <- dplyr::pull(cells, !! types)


### PR DESCRIPTION
This updates the implementation of `as_cells.xml_node()` to be forgiving of names like `...` and `..j`, which are now banned by default in the release candidate for _tibble_. Also, it removes some deprecation warnings. Note that warnings related to tidyselect are still shown.