### PR TITLE
Fix documentation for partition(align=) argument (switch dashes to underscores)

### DIFF
--- a/R/partition.R
+++ b/R/partition.R
@@ -14,8 +14,8 @@
 #'   tables.  Can also be cells that aren't among `cells`, in which case see the
 #'   `strict` argument.
 #' @param align Character, the position of the corner cells relative to their
-#'   tables, one of `"top-left"` (default), `"top-right"`, `"bottom-left"`,
-#'   `"bottom-right"`.
+#'   tables, one of `"top_left"` (default), `"top_right"`, `"bottom_left"`,
+#'   `"bottom_right"`.
 #' @param nest Logical, whether to nest the partitions in a list-column of data
 #'   frames.
 #' @param strict Logical, whether to omit partitions that don't contain a corner

--- a/man/partition.Rd
+++ b/man/partition.Rd
@@ -18,8 +18,8 @@ tables.  Can also be cells that aren't among \code{cells}, in which case see the
 \code{strict} argument.}
 
 \item{align}{Character, the position of the corner cells relative to their
-tables, one of \code{"top-left"} (default), \code{"top-right"}, \code{"bottom-left"},
-\code{"bottom-right"}.}
+tables, one of \code{"top_left"} (default), \code{"top_right"}, \code{"bottom_left"},
+\code{"bottom_right"}.}
 
 \item{nest}{Logical, whether to nest the partitions in a list-column of data
 frames.}


### PR DESCRIPTION
This fixes a minor documentation issue.