### PR TITLE
dplyr 1.1.0 compatibility

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2022 unpivotr authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/R/behead.R
+++ b/R/behead.R
@@ -203,11 +203,12 @@ behead_if.data.frame <- function(cells, ..., direction, name, values = NULL,
 # Construct a filter expression for stripping a header from a pivot table
 direction_filter <- function(direction) {
   direction <- substr(direction, 1L, 1L)
-  dplyr::case_when(
-    direction == "u" ~ rlang::expr(.data$row == min(.data$row)),
-    direction == "r" ~ rlang::expr(.data$col == max(.data$col)),
-    direction == "d" ~ rlang::expr(.data$row == max(.data$row)),
-    direction == "l" ~ rlang::expr(.data$col == min(.data$col))
+  switch(
+    direction,
+    u = rlang::expr(.data$row == min(.data$row)),
+    r = rlang::expr(.data$col == max(.data$col)),
+    d = rlang::expr(.data$row == max(.data$row)),
+    l = rlang::expr(.data$col == min(.data$col))
   )
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -110,14 +110,7 @@ concatenate <- function(..., combine_factors = TRUE, fill_factor_na = TRUE) {
 }
 
 # Return an NA of the same type as the given vector
-na_types <- list(
-  logical = NA,
-  integer = NA_integer_,
-  double = NA_real_,
-  character = NA_character_,
-  complex = NA_complex_
-)
-na_of_type <- function(x) structure(na_types[[typeof(x)]], class = class(x))
+na_of_type <- function(x) x[NA]
 
 # Apply custom functions to list-elements of a list-column created by pack()
 # whose type matches the custom function.


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

`case_when()` and `if_else()` now use vctrs, which generally makes them more permissive when there are varying types, but it resulted in two issues here:
- `case_when()` can now only return vector types, which was the intention from the beginning. It was returning expressions in one of your use cases, but could easily be replaced with a `switch()`
- The switch to vctrs resulted in surfacing this bug related to your `na_of_type()` function https://github.com/r-lib/vctrs/issues/1300. It is easier to just use `x[NA_integer_]` as a generic way to get the same thing in a way that vctrs is okay with. More importantly, in the dev version of dplyr you can just use `NA` so you won't need to worry about this at all after 1.1.0 is released! But for now we need the way I've done it to be compatible with dev and CRAN dplyr.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package in ahead of time! Thanks!