### PR TITLE
Fix tidyselect warning

### DIFF
--- a/R/pack.R
+++ b/R/pack.R
@@ -154,7 +154,7 @@ unpack <- function(cells, values = value, name = "data_type",
     )
   first_colnames <- setdiff(colnames(out), type_names)
   last_colnames <- sort(type_names)
-  out <- dplyr::select(out, first_colnames, last_colnames)
+  out <- dplyr::select(out, !!first_colnames, !!last_colnames)
   if (drop_packed) out <- dplyr::select(out, -!!values)
   out
 }

--- a/R/spatter.R
+++ b/R/spatter.R
@@ -150,6 +150,6 @@ spatter.data.frame <- function(cells, key, values = NULL, types = data_type,
   }
   first_colnames <- setdiff(colnames(out), new_colnames)
   last_colnames <- new_colnames
-  out <- dplyr::select(out, first_colnames, last_colnames)
+  out <- dplyr::select(out, !!first_colnames, !!last_colnames)
   out
 }


### PR DESCRIPTION
I tend to prefer `!!` to inject column names that come from a vector.