### PR TITLE
Replace deprecated timezone

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: unpivotr
 Title: Unpivot Complex and Irregular Data Layouts
-Version: 0.6.3
+Version: 0.6.4
 Authors@R: c(
     person("Duncan", "Garmonsway", email = "nacnudus@gmail.com", role = c("aut", "cre"))
     )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# unpivotr 0.6.4
+
+* Make tests compatible with recent versions of tzdata (CRAN)
+
 # unpivotr 0.6.3
 
 * Make compatible with dplyr v1.1.0 (#58 @DavisVaughan)

--- a/tests/testthat/test-concatenate.R
+++ b/tests/testthat/test-concatenate.R
@@ -101,7 +101,7 @@ test_that("concatenate() handles timezones", {
     )
   )
   x <- as.POSIXct("2018-01-01 01:00:00", tz = "UTC")
-  y <- as.POSIXct("2018-04-01 01:00:00", tz = "EST")
+  y <- as.POSIXct("2018-04-01 01:00:00", tz = "America/Panama")
   expect_equal(
     concatenate(list(x, y)),
     as.POSIXct(c(


### PR DESCRIPTION
As advised by CRAN.

  The errors on the Debian check systems are from a recent system upgrade
  to tzdata 2024b which did

     Names present only for compatibility with UNIX System V
     (last released in the 1990s) have been moved to 'backward'.

  which includes CET, CST6CDT, EET, EST*, HST, MET, MST*, PST8PDT, and
  WET.

  Debian ships the names in 'backward' in a separate package tzdata-legacy
  which is not installed "by default".

  The comments in the tzdata 'backward' file say

  # Although this file is optional and tzdb will work if you omit it by
  # building with 'make BACKWARD=', in practice downstream users
  # typically use this file for backward compatibility.

  so clearly one cannot unconditionally assume that the backward
  compatibility names will work.
